### PR TITLE
feat(analysis-trail): add per-item add controls and catalog search to…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,3 +113,4 @@ New categories may be added only if really needed and cannot be reasonably mappe
 ## Development Workflow Rules
 
 * Do not automatically trigger `bundle exec jekyll build` / `jekyll serve` after intermediate code edits during active iteration steps. Only run build commands when explicitly asked by the user or when all task changes are completely finished.
+* When a build is needed, prefer `bundle exec jekyll build --incremental` over a plain full build — it is much faster. A full (non-incremental) build is only needed when Markdown problem/solution content changed alongside the assets, since Jekyll's incremental mode does not reliably pick up every kind of content-side dependency. See "Fast Build for Styles and Scripts (Asset-Only)" above for the asset-only case this covers best.

--- a/assets/js/analysis-trail.js
+++ b/assets/js/analysis-trail.js
@@ -16,6 +16,11 @@
   var pendingAdd = null;
   // Node id the user started a connection from, or null when not connecting.
   var linkingFrom = null;
+  // Populated once from the page's [data-analysis-trail-catalog] script tag.
+  // Hoisted to module scope because both the add-node modal (defined in the
+  // init function) and the per-node reference menu (defined inside render())
+  // need to search the same catalog.
+  var catalog = { problems: [], solutions: [] };
 
   function stopLinking() {
     linkingFrom = null;
@@ -285,6 +290,97 @@
       type: kind === 'causes' ? 'root cause' : (kind === 'symptoms' ? 'symptom' : (match[1] === 'solutions' ? 'solution' : 'problem')),
       url: reference.url
     };
+  }
+
+  // Direction and label of the edge a reference of a given kind creates,
+  // shared by the per-item "+" button and the catalog search fallback.
+  function relationForKind(kind, sourceId, targetId) {
+    return {
+      symptoms: { from: targetId, to: sourceId, label: 'causes' },
+      causes: { from: sourceId, to: targetId, label: 'causes' },
+      solutions: { from: targetId, to: sourceId, label: 'addresses' },
+      'addressed-problems': { from: sourceId, to: targetId, label: 'addresses' },
+      'similar-problems': { from: sourceId, to: targetId, label: 'related' },
+      'similar-solutions': { from: sourceId, to: targetId, label: 'related' }
+    }[kind];
+  }
+
+  function catalogNodeTypeForKind(kind) {
+    if (kind === 'causes') return 'root cause';
+    if (kind === 'symptoms') return 'symptom';
+    if (kind === 'solutions' || kind === 'similar-solutions') return 'solution';
+    return 'problem';
+  }
+
+  function catalogPoolForKind(kind) {
+    return (kind === 'solutions' || kind === 'similar-solutions') ? catalog.solutions : catalog.problems;
+  }
+
+  // The manual search box searches everything, problems and solutions alike,
+  // rather than only the half `catalogPoolForKind` would restrict it to —
+  // each entry keeps its own real type so a solution is still labeled as a
+  // solution even when found from a "Causes" search.
+  function fullCatalogPool() {
+    return catalog.problems.map(function (item) {
+      return { id: item.id, title: item.title, url: item.url, type: 'problem' };
+    }).concat(catalog.solutions.map(function (item) {
+      return { id: item.id, title: item.title, url: item.url, type: 'solution' };
+    }));
+  }
+
+  // Adds one reference node and its edge to the trail without navigating away
+  // from the current page. Does not save/render on its own so a caller can
+  // batch several additions before doing either.
+  function addReferenceToTrail(trail, sourceNode, kind, referenceNode) {
+    addCurrentNode(trail, referenceNode);
+    var relation = relationForKind(kind, sourceNode.id, referenceNode.id);
+    if (relation && relation.from !== relation.to && !trail.edges.some(function (edge) {
+      return edge.from === relation.from && edge.to === relation.to && edge.label === relation.label;
+    })) trail.edges.push(relation);
+    if (trail.edges.length > maxEdges) trail.edges.shift();
+    saveTrail(trail);
+  }
+
+  // "Show more" prioritizes items that a handful of similar problems already
+  // list under the same heading, since those tend to be more relevant than an
+  // arbitrary slice of the full catalog. Falls back to the catalog to fill up
+  // to 20 suggestions.
+  function relatedSimilarKindFor(kind) {
+    if (kind === 'symptoms' || kind === 'causes' || kind === 'solutions') return 'similar-problems';
+    return null;
+  }
+
+  function collectShowMoreCandidates(sourceNode, kind, excludeIds) {
+    var pool = catalogPoolForKind(kind);
+    var similarKind = relatedSimilarKindFor(kind);
+    var similarPromise = similarKind ?
+      referencesForNode(sourceNode, similarKind).catch(function () { return []; }) :
+      window.Promise.resolve([]);
+    return similarPromise.then(function (similarReferences) {
+      var similarNodes = similarReferences.map(function (reference) {
+        return nodeFromReference(reference, similarKind);
+      }).filter(Boolean).slice(0, 6);
+      return window.Promise.all(similarNodes.map(function (similarNode) {
+        return referencesForNode(similarNode, kind).catch(function () { return []; });
+      })).then(function (groups) {
+        var prioritized = [];
+        var seen = {};
+        groups.forEach(function (group) {
+          group.forEach(function (reference) {
+            var candidateNode = nodeFromReference(reference, kind);
+            if (!candidateNode || seen[candidateNode.id] || excludeIds[candidateNode.id]) return;
+            seen[candidateNode.id] = true;
+            prioritized.push(candidateNode);
+          });
+        });
+        pool.forEach(function (item) {
+          if (prioritized.length >= 20 || seen[item.id] || excludeIds[item.id]) return;
+          seen[item.id] = true;
+          prioritized.push({ id: item.id, title: item.title, type: catalogNodeTypeForKind(kind), url: item.url });
+        });
+        return prioritized.slice(0, 20);
+      });
+    });
   }
 
   function addContextualCausalEdges(trail) {
@@ -712,51 +808,165 @@
           list.style.transform = 'none';
           nodeMenu.querySelectorAll('.analysis-trail__node-menu-list').forEach(function (item) { item.remove(); });
           nodeMenu.appendChild(list);
+          // Every row lets the user either open the reference's own page (title)
+          // or attach it to the graph right away without leaving this page ("+").
+          function renderAddableRow(candidateNode) {
+            var row = document.createElement('div');
+            row.className = 'analysis-trail__node-menu-list-item';
+            var isCustom = candidateNode.custom || !candidateNode.url || candidateNode.url === '#';
+            var titleControl = document.createElement(isCustom ? 'span' : 'button');
+            titleControl.className = 'analysis-trail__node-menu-list-title';
+            titleControl.textContent = candidateNode.title;
+            if (!isCustom) {
+              titleControl.type = 'button';
+              titleControl.addEventListener('click', function () {
+                navigateToReference(sourceNode, kind, candidateNode);
+              });
+            }
+            var addButton = document.createElement('button');
+            addButton.type = 'button';
+            addButton.className = 'analysis-trail__node-menu-list-add';
+            addButton.title = 'Add to the graph without leaving this page';
+            addButton.setAttribute('aria-label', 'Add ' + candidateNode.title + ' to the graph');
+            addButton.textContent = '+';
+            addButton.addEventListener('click', function () {
+              rememberChange(trail);
+              addReferenceToTrail(trail, sourceNode, kind, candidateNode);
+              addButton.disabled = true;
+              addButton.textContent = '✓';
+              render(trail);
+            });
+            row.appendChild(titleControl);
+            row.appendChild(addButton);
+            return row;
+          }
+
+          // Sits at the top of the list: a plain search over every problem or
+          // solution in the catalog (whichever this kind draws from), not just
+          // what is already linked below — that list already covers "local".
+          // Falls back to creating a custom node when nothing matches.
+          var searchWrap = document.createElement('div');
+          searchWrap.className = 'analysis-trail__node-menu-search';
+          var searchInput = document.createElement('input');
+          searchInput.type = 'text';
+          searchInput.className = 'analysis-trail__node-menu-search-input';
+          searchInput.placeholder = 'Search…';
+          searchInput.setAttribute('aria-label', 'Search or add a new ' + kind + ' node');
+          var searchResults = document.createElement('div');
+          searchResults.className = 'analysis-trail__node-menu-search-results';
+          searchResults.setAttribute('role', 'listbox');
+          searchResults.hidden = true;
+
+          // Rows already rendered below (references plus "Show more" picks),
+          // excluded from the catalog search so it never suggests a duplicate.
+          var shownIds = {};
+          shownIds[sourceNode.id] = true;
+
+          function addAndClose(candidateNode) {
+            rememberChange(trail);
+            addReferenceToTrail(trail, sourceNode, kind, candidateNode);
+            searchInput.value = '';
+            searchResults.hidden = true;
+            render(trail);
+          }
+
+          function updateSearch() {
+            searchResults.innerHTML = '';
+            var query = searchInput.value.trim();
+            if (!query) { searchResults.hidden = true; return; }
+            var lowerQuery = query.toLowerCase();
+            var matches = fullCatalogPool().filter(function (item) {
+              return item.id !== sourceNode.id && !shownIds[item.id] &&
+                !trail.nodes.some(function (existing) { return existing.id === item.id; }) &&
+                item.title.toLowerCase().indexOf(lowerQuery) !== -1;
+            }).slice(0, 8);
+            // Same mechanism as the reference rows above: the title opens the
+            // article, the round "+" attaches it without navigating away. A
+            // matched problem still takes this kind's type (root cause,
+            // symptom, ...); a matched solution stays a solution regardless.
+            matches.forEach(function (item) {
+              var type = item.type === 'solution' ? 'solution' : catalogNodeTypeForKind(kind);
+              var row = renderAddableRow({ id: item.id, title: item.title, type: type, url: item.url });
+              row.setAttribute('role', 'option');
+              searchResults.appendChild(row);
+            });
+            var custom = document.createElement('button');
+            custom.type = 'button';
+            custom.className = 'analysis-trail__node-menu-search-custom';
+            custom.textContent = 'Add "' + query + '" as a new node';
+            custom.addEventListener('click', function () {
+              addAndClose({
+                id: 'custom:' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+                title: query,
+                type: catalogNodeTypeForKind(kind),
+                custom: true,
+                url: '#'
+              });
+            });
+            searchResults.appendChild(custom);
+            searchResults.hidden = false;
+          }
+
+          searchInput.addEventListener('input', updateSearch);
+          searchInput.addEventListener('keydown', function (event) {
+            if (event.key === 'Enter') {
+              // Enter quick-adds the top hit instead of navigating to it, so it
+              // takes the same "+" a click would use, not the title link.
+              var first = searchResults.querySelector('.analysis-trail__node-menu-list-add') ||
+                searchResults.querySelector('.analysis-trail__node-menu-search-custom');
+              if (first) first.click();
+            }
+            if (event.key === 'Escape') { searchInput.value = ''; updateSearch(); }
+          });
+
+          searchWrap.appendChild(searchInput);
+          searchWrap.appendChild(searchResults);
+          list.appendChild(searchWrap);
+
           referencesForNode(sourceNode, kind).then(function (references) {
-            list.innerHTML = '';
-            if (!references.length) {
-              list.textContent = 'No references.';
-              return;
-            }
-            function addReference(reference) {
-              var referenceButton = document.createElement('button');
-              referenceButton.type = 'button';
-              referenceButton.textContent = reference.title;
-              referenceButton.addEventListener('click', function () {
-                navigateToReference(sourceNode, kind, reference);
-              });
-              list.appendChild(referenceButton);
-            }
-            references.forEach(addReference);
             if (references.length) {
-              var showAll = document.createElement('button');
-              showAll.type = 'button';
-              showAll.className = 'analysis-trail__node-menu-show-all';
-              showAll.textContent = 'Add all nodes (' + references.length + ')';
-              showAll.addEventListener('click', function () {
-                showAll.remove();
-                references.forEach(function (reference) {
-                  var referenceNode = nodeFromReference(reference, kind);
-                  if (!referenceNode) return;
-                  addCurrentNode(trail, referenceNode);
-                  var relation = {
-                    symptoms: { from: referenceNode.id, to: sourceNode.id, label: 'causes' },
-                    causes: { from: sourceNode.id, to: referenceNode.id, label: 'causes' },
-                    solutions: { from: referenceNode.id, to: sourceNode.id, label: 'addresses' },
-                    'addressed-problems': { from: sourceNode.id, to: referenceNode.id, label: 'addresses' },
-                    'similar-problems': { from: sourceNode.id, to: referenceNode.id, label: 'related' },
-                    'similar-solutions': { from: sourceNode.id, to: referenceNode.id, label: 'related' }
-                  }[kind];
-                  if (relation && relation.from !== relation.to && !trail.edges.some(function (edge) {
-                    return edge.from === relation.from && edge.to === relation.to && edge.label === relation.label;
-                  })) trail.edges.push(relation);
-                });
-                saveTrail(trail);
-                render(trail);
+              references.forEach(function (reference) {
+                var candidateNode = nodeFromReference(reference, kind);
+                if (!candidateNode) return;
+                shownIds[candidateNode.id] = true;
+                list.appendChild(renderAddableRow(candidateNode));
               });
-              list.appendChild(showAll);
+            } else {
+              var empty = document.createElement('p');
+              empty.className = 'analysis-trail__node-menu-empty';
+              empty.textContent = 'No linked references yet.';
+              list.appendChild(empty);
             }
-          }).catch(function () { list.textContent = 'Could not load references.'; });
+
+            var showMore = document.createElement('button');
+            showMore.type = 'button';
+            showMore.className = 'analysis-trail__node-menu-show-all';
+            showMore.textContent = 'Show more';
+            showMore.addEventListener('click', function () {
+              showMore.disabled = true;
+              showMore.textContent = 'Loading…';
+              trail.nodes.forEach(function (existing) { shownIds[existing.id] = true; });
+              collectShowMoreCandidates(sourceNode, kind, shownIds).then(function (candidates) {
+                showMore.remove();
+                if (!candidates.length) {
+                  var none = document.createElement('p');
+                  none.className = 'analysis-trail__node-menu-empty';
+                  none.textContent = 'No further catalog matches.';
+                  list.appendChild(none);
+                  return;
+                }
+                list.classList.add('is-expanded');
+                candidates.forEach(function (candidateNode) {
+                  shownIds[candidateNode.id] = true;
+                  list.appendChild(renderAddableRow(candidateNode));
+                });
+              }).catch(function () {
+                showMore.disabled = false;
+                showMore.textContent = 'Show more';
+              });
+            });
+            list.appendChild(showMore);
+          }).catch(function () { list.appendChild(document.createTextNode('Could not load references.')); });
         }
         action.addEventListener('click', openActionList);
         nodeMenu.appendChild(action);
@@ -1147,7 +1357,6 @@
     if (addModal && addModal.parentElement !== document.body) document.body.appendChild(addModal);
     var addSearchResults = document.querySelector('[data-analysis-trail-add-search-results]');
     var addSelection = document.querySelector('[data-analysis-trail-add-selection]');
-    var catalog = { problems: [], solutions: [] };
     try { catalog = JSON.parse(document.querySelector('[data-analysis-trail-catalog]').textContent); } catch (error) { catalog = { problems: [], solutions: [] }; }
 
     function closeAddModal() {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -320,6 +320,144 @@
   &__node-menu-show-all { font-weight: bold; text-align: center !important; }
   &__node-menu--add { width: max-content; height: auto; pointer-events: auto; }
   &__node-menu--add .analysis-trail__node-menu-action { min-width: 9.5rem; text-align: left; }
+
+  // One existing reference rendered as a single pill: the title opens the
+  // page, the round "+" inside the same box attaches it to the graph right
+  // away without navigating away.
+  &__node-menu-list-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    border: 1.5px solid #80bfff;
+    border-radius: 10px;
+    padding: 0.35rem 0.35rem 0.35rem 0.9rem;
+    background: #fff;
+    box-shadow: 0 4px 14px rgba(0, 102, 178, 0.2);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover, &:focus-within {
+      border-color: #007acc;
+      box-shadow: 0 6px 18px rgba(0, 122, 204, 0.4);
+    }
+  }
+  &__node-menu-list-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0.25rem 0 !important;
+    color: #0066b2;
+    text-align: left;
+
+    // The generic `.analysis-trail__node-menu-list button:hover` rule outranks
+    // a plain class selector (it also matches on the `button` tag), and would
+    // otherwise win with white text over this transparent background —
+    // invisible. `!important` is needed to actually land the deep-blue hover.
+    &:hover, &:focus {
+      background: transparent !important;
+      color: #004c85 !important;
+      box-shadow: none !important;
+      transform: none !important;
+    }
+  }
+  span.analysis-trail__node-menu-list-title {
+    color: #555;
+    cursor: default;
+  }
+  &__node-menu-list-add {
+    flex: 0 0 auto;
+    width: 1.7rem;
+    height: 1.7rem;
+    border: 1.5px solid #80bfff !important;
+    border-radius: 50% !important;
+    padding: 0 !important;
+    background: #edf6ff;
+    color: #0066b2;
+    text-align: center !important;
+    font-size: 1.1rem !important;
+    line-height: 1 !important;
+    box-shadow: none !important;
+
+    &:hover, &:focus {
+      background: #007acc;
+      color: #fff;
+      border-color: #007acc !important;
+      transform: scale(1.08) !important;
+    }
+  }
+  &__node-menu-list-add:disabled {
+    opacity: 0.6;
+    cursor: default;
+    transform: none !important;
+
+    &:hover, &:focus {
+      background: #edf6ff;
+      color: #0066b2;
+      border-color: #80bfff !important;
+      transform: none !important;
+    }
+  }
+  &__node-menu-empty {
+    margin: 0;
+    color: #666;
+    font-size: 0.85rem;
+    font-weight: normal;
+    line-height: 1.4;
+  }
+
+  // Catalog search for this reference kind, plus the "create a new node"
+  // fallback when nothing in the catalog matches the query.
+  &__node-menu-search {
+    position: relative;
+    margin-top: 0.35rem;
+    padding-top: 0.6rem;
+    border-top: 1px solid #dceafd;
+  }
+  &__node-menu-search-input {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0.5rem 0.7rem;
+    border: 1.5px solid #80bfff;
+    border-radius: 8px;
+    background: #fff;
+    color: #222;
+    font: inherit;
+    font-size: 0.9rem;
+  }
+  &__node-menu-search-results {
+    display: grid;
+    gap: 0.4rem;
+    margin-top: 0.4rem;
+    max-height: 10rem;
+    overflow-y: auto;
+    padding: 0.4rem;
+    border: 1.5px solid #80bfff;
+    border-radius: 8px;
+
+    &[hidden] { display: none; }
+
+    // Only the flat "create a new node" fallback lives directly in here — the
+    // catalog matches above it are full `&__node-menu-list-item` pills, which
+    // already carry their own styling and must not be flattened by this rule.
+    > button {
+      border: 1.5px dashed #80bfff;
+      border-radius: 8px;
+      padding: 0.55rem 0.75rem;
+      font-size: 0.9rem;
+      font-weight: normal;
+      box-shadow: none;
+
+      &:hover, &:focus { box-shadow: none; transform: none; }
+    }
+  }
+  &__node-menu-search-custom {
+    color: #0066b2;
+    font-style: italic;
+  }
   &__node-hover-hit {
     fill: rgba(0, 0, 0, 0.001);
     stroke: none;
@@ -519,16 +657,22 @@
 }
 
 @media screen and (min-width: 701px) {
+  // The article column scrolls inside its own box instead of the document.
+  // Without this, the native scrollbar for the article sat at the outer edge
+  // of the browser window — behind the fixed workbench pane, nowhere near the
+  // column it actually scrolled — instead of hugging the article itself.
   body.analysis-trail-expanded {
-    display: block;
-    min-height: 100vh;
-    overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
   }
 
   body.analysis-trail-expanded .site-header,
   body.analysis-trail-expanded .site-footer {
     position: relative;
     z-index: 21;
+    flex: 0 0 auto;
     width: var(--analysis-trail-split, 50%);
     box-sizing: border-box;
     background: #fff;
@@ -555,9 +699,10 @@
   }
 
   body.analysis-trail-expanded .page-content {
+    flex: 1 1 auto;
     width: var(--analysis-trail-split, 50%);
-    height: auto;
-    overflow: visible;
+    min-height: 0;
+    overflow-y: auto;
     overflow-x: hidden;
   }
 
@@ -571,7 +716,12 @@
     }
 
     .analysis-trail {
-      display: block;
+      // A flex column, rather than a fixed calc() height on the graph, lets it
+      // claim exactly whatever room the header and legend do not need instead
+      // of a conservative estimate that left it stuck near the top with dead
+      // space below.
+      display: flex;
+      flex-direction: column;
       position: fixed;
       z-index: 20;
       top: 0;
@@ -657,11 +807,14 @@
       }
 
       &__graph {
-        max-height: calc(100vh - 275px);
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none;
       }
 
       &__graph svg {
-        min-height: calc(100vh - 300px);
+        height: 100%;
+        min-height: 0;
       }
     }
   }


### PR DESCRIPTION
… node menu

- Give the workbench graph flex-based sizing instead of a fixed calc() height, so it fills the expanded panel instead of sitting stuck near the top with dead space below.
- Each reference row in a node's Symptoms/Causes/Solutions/... menu now shows a round "+" inside the same pill as the title: the title opens the page, "+" attaches the node to the graph without navigating away.
- Replace the "Add all nodes" bulk action with "Show more", which pulls in up to 20 additional catalog candidates, preferring ones already used by similar problems under the same heading.
- Add a search box to each reference kind's menu that searches the full problem+solution catalog (not just what's already linked) and falls back to creating a custom node when nothing matches.
- Fix a hover state where the reference title button went invisible (white text with no background) because a more specific existing rule outranked the intended deep-blue hover color.
- Make the article column scroll inside its own box (flex body layout) instead of the document, so its scrollbar sits next to the article instead of behind the fixed workbench pane.
- Note in CLAUDE.md that builds should prefer --incremental.